### PR TITLE
fix: calculate lastPage

### DIFF
--- a/src/components/Pagination/index.tsx
+++ b/src/components/Pagination/index.tsx
@@ -24,7 +24,7 @@ export function Pagination({
   currentPage = 1,
   onPageChange,
 }: PaginationProps) {
-  const lastPage = Math.floor(totalCountOfRegisters / registersPerPage);
+  const lastPage = Math.ceil(totalCountOfRegisters / registersPerPage);
 
   const previousPages = currentPage > 1
     ? generatePagesArray(currentPage - 1 - siblingsCount, currentPage - 1)


### PR DESCRIPTION
Fix calculate to count lastPage correct.
Example:
Math.floor(201/10)  // :heavy_multiplication_x: 20 wrong
Math.ceil(201/10)   // :heavy_check_mark: 21 correct